### PR TITLE
Bugfixes II

### DIFF
--- a/repository/Topez-Server-24x-Core.package/TDAbstractEnvironment.extension/instance/_compile.inContext.literalVars.tempSymbolList.environmentId..st
+++ b/repository/Topez-Server-24x-Core.package/TDAbstractEnvironment.extension/instance/_compile.inContext.literalVars.tempSymbolList.environmentId..st
@@ -1,4 +1,4 @@
-*topez-server-3x-core
+*topez-server-24x-core
 _compile: aString inContext: compilationContext literalVars: litVarArrayOrNil tempSymbolList: tempSymbolList environmentId: environmentId
   ^ self
     _compileBlock: [ :symbolList | 

--- a/repository/Topez-Server-24x-Core.package/TDAbstractEnvironment.extension/instance/_compile.inContext.literalVars.tempSymbolList.environmentId..st
+++ b/repository/Topez-Server-24x-Core.package/TDAbstractEnvironment.extension/instance/_compile.inContext.literalVars.tempSymbolList.environmentId..st
@@ -1,0 +1,10 @@
+*topez-server-3x-core
+_compile: aString inContext: compilationContext literalVars: litVarArrayOrNil tempSymbolList: tempSymbolList environmentId: environmentId
+  ^ self
+    _compileBlock: [ :symbolList | 
+      ^ aString
+        _compileInContext: compilationContext
+        symbolList: symbolList , tempSymbolList
+        oldLitVars: litVarArrayOrNil
+        environmentId: environmentId
+        flags: 0 ]

--- a/repository/Topez-Server-24x-Core.package/TDAbstractEnvironment.extension/methodProperties.json
+++ b/repository/Topez-Server-24x-Core.package/TDAbstractEnvironment.extension/methodProperties.json
@@ -2,5 +2,4 @@
 	"class" : {
 		 },
 	"instance" : {
-		"_compile:inContext:literalVars:tempSymbolList:" : "dkh 03/29/2017 11:11",
-		"_compile:inContext:tempSymbolList:" : "dkh 12/27/2016 11:14" } }
+		"_compile:inContext:literalVars:tempSymbolList:environmentId:" : "dkh 10/31/2017 12:07" } }


### PR DESCRIPTION
Fix a couple of additional issues that popped up during [GsDevKit_home testing](https://travis-ci.org/GsDevKit/GsDevKit_home) after the [recent release](https://github.com/dalehenrich/tode/pull/297).

### Bugfixes
1. fix issue preventing tODE logins for Gemstone 2.4.x stones

## Update Script for Client
```
updateGsDevKit -ti                 # to update tODE repo and rebuild tODE clients
```
## Update Script for Server
```
$GS_HOME/bin/updateGsDevKit -ti              # to update tODE repo and rebuild tODE clients
$GS_HOME/bin/todeUpdate <stone-name>         # to load tODE update into your stone
```